### PR TITLE
Fix/167 default ref to git

### DIFF
--- a/src/views/trainings/TrainingEditablePage.tsx
+++ b/src/views/trainings/TrainingEditablePage.tsx
@@ -27,7 +27,7 @@ function defaultTrainingSpec(mts?: ModelTrainingSpec): ModelTrainingSpec {
         envs: [],
         model: {name: '', version: ''},
         vcsName: '',
-        reference: 'develop',
+        reference: '',
         workDir: './',
         outputConnection: '',
         resources: {


### PR DESCRIPTION
* If during the creation of git conn, I indicated `reference` other than `develop` or did not indicate at all, then when creating the training I get `develop` as default whatever I put during creation of the connection.