### PR TITLE
[#34] FIx ID validation regex

### DIFF
--- a/src/utils/enities.ts
+++ b/src/utils/enities.ts
@@ -41,7 +41,7 @@ export function deepCopy<T>(entity: T): T {
     return JSON.parse(JSON.stringify(entity));
 }
 
-const ID_REGEX = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])$/;
+const ID_REGEX = /^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$/;
 export const ID_MAX_LENGTH = 63;
 
 /**


### PR DESCRIPTION
Fixes #34 
Prohibit IDs starting with number. 
Corresponding backend validation: https://github.com/odahu/odahu-flow/pull/350