### PR TITLE
Fix/11 Not correct update form state

### DIFF
--- a/src/components/EntitiyFetching.tsx
+++ b/src/components/EntitiyFetching.tsx
@@ -8,6 +8,7 @@ import {useParams} from "react-router-dom";
 
 export interface FetchHookOutput<T> {
     loading: boolean;
+    setEntity: (value: T) => void;
     notFound: boolean;
     entity: T;
 }
@@ -16,11 +17,11 @@ export function useFetchingEntity<T>(id: string, fetchAction: (id: string) => As
     const dispatch: any = useDispatch();
     const [loading, setLoading] = useState<boolean>(true);
     const [notFound, setNotFound] = useState<boolean>(false);
-    const [entity, seEntity] = useState<T>({} as T);
+    const [entity, setEntity] = useState<T>({} as T);
 
     if (loading) {
         dispatch(fetchAction(id)).then((entity: T) => {
-            seEntity(entity);
+            setEntity(entity);
         }).catch((err: any) => {
             dispatch(showErrorAlert("Error", String(err)));
             setNotFound(true);
@@ -29,7 +30,7 @@ export function useFetchingEntity<T>(id: string, fetchAction: (id: string) => As
         });
     }
 
-    return {loading, notFound, entity};
+    return {loading, notFound, entity, setEntity: setEntity};
 }
 
 export type FetchingEntityProps<T> = {

--- a/src/components/actions.ts
+++ b/src/components/actions.ts
@@ -42,8 +42,6 @@ export class SaveButtonClick<T> {
         dispatch(this.createAction(entity)).then(() => {
             return dispatch(showSuccessAlert('Success', this.successMessage));
         }).then(() => {
-            return dispatch(this.fetchAllAction());
-        }).then(() => {
             if (setRedirect) {
                 setRedirect(true);
             }

--- a/src/components/actions.ts
+++ b/src/components/actions.ts
@@ -9,18 +9,23 @@ export class SaveButtonClick<T> {
     private createAction: (entity: T) => AsyncAction<Promise<T>>;
     private fetchAllAction: () => AsyncAction;
     private successMessage: string;
+    private successCallback?: (entity: T) => void;
 
     /**
      * @param modifyAction - redux action that allows creating or editing of Odahu entity
      * @param fetchAllAction - redux action that fetch a type of Odahu entities from API server
      * @param successMessage - a message that appears after successful modifyAction
+     * @param successCallback - a function that will be called after successful processing of update logic
      */
     constructor(modifyAction: (entity: T) => AsyncAction<Promise<T>>,
                 fetchAllAction: () => AsyncAction,
-                successMessage: string) {
+                successMessage: string,
+                successCallback?: (entity: T) => void
+                ) {
         this.createAction = modifyAction;
         this.fetchAllAction = fetchAllAction;
         this.successMessage = successMessage;
+        this.successCallback = successCallback;
     }
 
     /**
@@ -41,6 +46,10 @@ export class SaveButtonClick<T> {
         }).then(() => {
             if (setRedirect) {
                 setRedirect(true);
+            }
+        }).then(() => {
+            if(this.successCallback) {
+                this.successCallback(entity)
             }
         }).catch((err: string) => {
             dispatch(showErrorAlert("Error", String(err)));

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -3,7 +3,7 @@ import {ApplicationState, createRootReducer} from "./store";
 import thunk from "redux-thunk";
 import {Services} from "./services";
 import {ConnectionService} from "./services/connections";
-import {composeWithDevTools} from 'redux-devtools-extension';
+import {composeWithDevTools, EnhancerOptions} from 'redux-devtools-extension';
 import {ConfigurationService} from "./services/configuration";
 import {DeploymentService} from "./services/deployments";
 import {PackagingService} from "./services/packaging";
@@ -14,17 +14,28 @@ import {UserService} from "./services/user";
 
 
 export function configureStore(): Store<ApplicationState> {
+
+    let opts: EnhancerOptions = {}
+    if (process.env.NODE_ENV === 'development') {
+        opts.trace = true
+        opts.traceLimit = 15
+        console.log("dev mode")
+    }
+    const composeEnhancers = composeWithDevTools(opts)
+
     return createStore(
         createRootReducer,
-        composeWithDevTools(applyMiddleware(thunk.withExtraArgument<Services>({
-            connectionService: new ConnectionService(),
-            configurationService: new ConfigurationService(),
-            userService: new UserService(),
-            deploymentService: new DeploymentService(),
-            packagingService: new PackagingService(),
-            packagerService: new PackagerIntegrationService(),
-            trainingService: new TrainingService(),
-            toolchainService: new TrainingToolchainService(),
-        })))
+        composeEnhancers(
+            applyMiddleware(thunk.withExtraArgument<Services>({
+                connectionService: new ConnectionService(),
+                configurationService: new ConfigurationService(),
+                userService: new UserService(),
+                deploymentService: new DeploymentService(),
+                packagingService: new PackagingService(),
+                packagerService: new PackagerIntegrationService(),
+                trainingService: new TrainingService(),
+                toolchainService: new TrainingToolchainService(),
+            }))
+        )
     );
 }

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -15,7 +15,7 @@ import {UserService} from "./services/user";
 
 export function configureStore(): Store<ApplicationState> {
 
-    let opts: EnhancerOptions = {}
+    const opts: EnhancerOptions = {}
     if (process.env.NODE_ENV === 'development') {
         opts.trace = true
         opts.traceLimit = 15

--- a/src/store/connections/reducer.ts
+++ b/src/store/connections/reducer.ts
@@ -31,12 +31,14 @@ export const connectionReducer: Reducer<ConnectionState, actionType> = (state = 
             return {...state, error: action.error, loading: false}
         }
         case ConnectionActionTypes.FETCH_SUCCESS: {
+            const data = {
+                ...state.data,
+                [action.payload.connection.id as string]: action.payload.connection,
+            }
             return {
-                data: {
-                    [action.payload.connection.id as string]: action.payload.connection,
-                    ...state.data,
-                },
                 ...state,
+                data: data,
+                length: Object.keys(data).length,
             }
         }
         default:

--- a/src/store/deployments/reducer.ts
+++ b/src/store/deployments/reducer.ts
@@ -31,12 +31,14 @@ export const deploymentReducer: Reducer<ModelDeploymentState, actionType> = (sta
             return {...state, error: action.error, loading: false}
         }
         case DeploymentsActionTypes.FETCH_SUCCESS: {
+            const data = {
+                ...state.data,
+                [action.payload.deployment.id as string]: action.payload.deployment,
+            }
             return {
-                data: {
-                    [action.payload.deployment.id as string]: action.payload.deployment,
-                    ...state.data,
-                },
                 ...state,
+                data: data,
+                length: Object.keys(data).length,
             }
         }
         default:

--- a/src/store/deployments/types.ts
+++ b/src/store/deployments/types.ts
@@ -1,8 +1,17 @@
 import {ModelDeployment} from "../../models/odahuflow/ModelDeployment";
+import {ApplicationState} from "../index";
 
 export interface ModelDeploymentState {
     readonly loading: boolean;
     readonly data: Record<string, ModelDeployment>;
     readonly length: number;
     readonly error?: string;
+}
+
+export const MDSSelector = (state: ApplicationState) => state.deployments
+
+
+export const createMDSelector = (id: string) => (state: ApplicationState): ModelDeployment => {
+    const mdState = MDSSelector(state)
+    return mdState.data[id] ?? {}
 }

--- a/src/store/packagers/reducer.ts
+++ b/src/store/packagers/reducer.ts
@@ -31,12 +31,14 @@ export const packagerReducer: Reducer<PackagerState, actionType> = (state = init
             return {...state, error: action.error, loading: false}
         }
         case PackagerActionTypes.FETCH_SUCCESS: {
+            const data = {
+                ...state.data,
+                [action.payload.packager.id as string]: action.payload.packager,
+            }
             return {
-                data: {
-                    [action.payload.packager.id as string]: action.payload.packager,
-                    ...state.data,
-                },
                 ...state,
+                data: data,
+                length: Object.keys(data).length,
             }
         }
         default:

--- a/src/store/packaging/reducer.ts
+++ b/src/store/packaging/reducer.ts
@@ -31,12 +31,14 @@ export const packagingReducer: Reducer<ModelPackagingState, actionType> = (state
             return {...state, error: action.error, loading: false}
         }
         case PackagingActionTypes.FETCH_SUCCESS: {
+            const data = {
+                ...state.data,
+                [action.payload.packaging.id as string]: action.payload.packaging,
+            }
             return {
-                data: {
-                    [action.payload.packaging.id as string]: action.payload.packaging,
-                    ...state.data,
-                },
                 ...state,
+                data: data,
+                length: Object.keys(data).length,
             }
         }
         default:

--- a/src/store/toolchains/reducer.ts
+++ b/src/store/toolchains/reducer.ts
@@ -31,12 +31,14 @@ export const toolchainReducer: Reducer<ToolchainState, actionType> = (state = in
             return {...state, error: action.error, loading: false}
         }
         case ToolchainActionTypes.FETCH_SUCCESS: {
+            const data = {
+                ...state.data,
+                [action.payload.toolchain.id as string]: action.payload.toolchain,
+            }
             return {
-                data: {
-                    [action.payload.toolchain.id as string]: action.payload.toolchain,
-                    ...state.data,
-                },
                 ...state,
+                data: data,
+                length: Object.keys(data).length,
             }
         }
         default:

--- a/src/store/trainings/reducer.ts
+++ b/src/store/trainings/reducer.ts
@@ -31,12 +31,14 @@ export const trainingReducer: Reducer<ModelTrainingState, actionType> = (state =
             return {...state, error: action.error, loading: false}
         }
         case TrainingActionTypes.FETCH_SUCCESS: {
+            const data = {
+                ...state.data,
+                [action.payload.training.id as string]: action.payload.training,
+            }
             return {
-                data: {
-                    [action.payload.training.id as string]: action.payload.training,
-                    ...state.data,
-                },
                 ...state,
+                data: data,
+                length: Object.keys(data).length,
             }
         }
         default:

--- a/src/views/connections/ConnectionViewPage.tsx
+++ b/src/views/connections/ConnectionViewPage.tsx
@@ -14,16 +14,18 @@ import {ConnectionView} from "./ConnectionView";
 import {useFetchingEntity} from "../../components/EntitiyFetching";
 
 const tabHeaders = ["View", "Edit", "YAML"];
-const editButtonClick = new SaveButtonClick<Connection>(
-    editConnectionRequest,
-    fetchAllConnectionRequest,
-    "Connection submitted",
-);
 
 export const ConnectionViewPage: React.FC = () => {
     const {id} = useParams();
 
-    const {entity, loading, notFound} = useFetchingEntity(id as string, fetchConnectionRequest);
+    const {entity, loading, notFound, setEntity} = useFetchingEntity(id as string, fetchConnectionRequest);
+
+    const editButtonClick = new SaveButtonClick<Connection>(
+        editConnectionRequest,
+        fetchAllConnectionRequest,
+        "Connection submitted",
+        (conn) => {setEntity(conn)}
+    );
 
     return (
         <ViewPage

--- a/src/views/deployments/DeploymentViewPage.tsx
+++ b/src/views/deployments/DeploymentViewPage.tsx
@@ -14,16 +14,16 @@ import {EditableDeploymentPage} from "./DeploymentPages";
 import {useFetchingEntity} from "../../components/EntitiyFetching";
 import {createDashboardURL, GrafanaDashboard} from "../../components/Dashboard";
 
-const saveButtonClick = new SaveButtonClick<ModelDeployment>(
-    editDeploymentRequest,
-    fetchAllDeploymentRequest,
-    "Model Deployment submitted",
-);
-
 export const DeploymentViewPage: React.FC = () => {
     const {id} = useParams();
+    const {entity, loading, notFound, setEntity} = useFetchingEntity(id as string, fetchDeploymentRequest);
 
-    const {entity, loading, notFound} = useFetchingEntity(id as string, fetchDeploymentRequest);
+    const saveButtonClick = new SaveButtonClick<ModelDeployment>(
+        editDeploymentRequest,
+        fetchAllDeploymentRequest,
+        "Model Deployment submitted",
+        (md) => {setEntity(md)}
+    );
 
     return (
         <ViewPage

--- a/src/views/packagings/PackagingViewPage.tsx
+++ b/src/views/packagings/PackagingViewPage.tsx
@@ -20,18 +20,20 @@ import {useSelector} from "react-redux";
 import {ApplicationState} from "../../store";
 import {ConfigurationState} from "../../store/configuration/types";
 
-const saveButtonClick = new SaveButtonClick<ModelPackaging>(
-    editPackagingRequest,
-    fetchAllPackagingRequest,
-    "Model Packaging submitted",
-);
 
 export const PackagingViewPage: React.FC = () => {
     const config = useSelector<ApplicationState, ConfigurationState>(state => state.configuration);
     const {id} = useParams();
     const kibanaEnabled = (config.data.common?.externalUrls?.map((i) => i.name == 'Kibana').indexOf(true) == -1) ? false : true;
 
-    const {entity, loading, notFound} = useFetchingEntity(id as string, fetchPackagingRequest);
+    const {entity, loading, notFound, setEntity} = useFetchingEntity(id as string, fetchPackagingRequest);
+
+    const saveButtonClick = new SaveButtonClick<ModelPackaging>(
+        editPackagingRequest,
+        fetchAllPackagingRequest,
+        "Model Packaging submitted",
+        (pack) => {setEntity(pack)}
+    );
 
     const logsView = (kibanaEnabled == false) ? <LogsView
                                                  key="logs"

--- a/src/views/trainings/TrainingPage.tsx
+++ b/src/views/trainings/TrainingPage.tsx
@@ -21,17 +21,18 @@ import {ApplicationState} from "../../store";
 import {ConfigurationState} from "../../store/configuration/types";
 
 const tabHeaders = ["View", "Edit", "YAML", "Logs", "Dashboard"];
-const editableSaveButtonClick = new SaveButtonClick<ModelTraining>(
-    editTrainingRequest,
-    fetchAllTrainingRequest,
-    "Model Training submitted",
-);
 
 export const TrainingPage: React.FC = () => {
     const config = useSelector<ApplicationState, ConfigurationState>(state => state.configuration);
     const {id} = useParams();
 
-    const {entity, loading, notFound} = useFetchingEntity(id as string, fetchTrainingRequest);
+    const {entity, loading, notFound, setEntity} = useFetchingEntity(id as string, fetchTrainingRequest);
+    const editableSaveButtonClick = new SaveButtonClick<ModelTraining>(
+        editTrainingRequest,
+        fetchAllTrainingRequest,
+        "Model Training submitted",
+        (training) => {setEntity(training)}
+    );
 
     const kibanaEnabled = (config.data.common?.externalUrls?.map((i) => i.name == 'Kibana').indexOf(true) == -1) ? false : true;
  


### PR DESCRIPTION
closes #11 

Before:
* When user updates any form (connection / training etc) and then travels through form tabs – changes that user made are gone despite of they are pushed to server and redux store is up to date 

After:
* Form state is fixed immediately  after successful PUT request, so tabs traveling do not affect it



 Details:

* Add callback for local form state update for TrainingPage.tsx, PackagingViewPage.tsx, ConnectionViewPage.tsx  
* saveButtonClick in DeploymentViewPage.tsx must update local state after successful api request 
* Fix reducers for FETCH_SUCCESS action to properly update store  
* SaveButtonClick – remove dispatching of fetchAllAction  because reducer of createAction must be sufficient to update store in right way
* SaveButtonClick – optional successCallback class parameter 
* useFetchingEntity hook – refactor seEntity -> setEntity  
* useFetchingEntity hook – return setEntity to the Caller
* Add selectors for deployment state 
* Fix deploy reducer (order for ... spreading operator does matter)
* Enable actions tracing for dev mode