### PR TITLE
`Reference` field is optional for VCS connection [#7 fix] [#50 fix]

### DIFF
--- a/src/components/OdahuAutocomplete.tsx
+++ b/src/components/OdahuAutocomplete.tsx
@@ -59,7 +59,7 @@ export const OdahuAutocomplete: React.FC<OdahuAutocompleteProps> = (
             freeSolo
             className={className ?? classes.fields}
             onChange={(event, newValue) => {
-                formik.setFieldValue(name, newValue);
+                formik.setFieldValue(name, newValue ?? "");
             }}
             value={value}
             options={options}


### PR DESCRIPTION
closes #7 #50 

Before: 
* If user clear `reference` field using clear button so this field does not pass validation despite of it is optional
* Validation tip is not human friendly
![image](https://user-images.githubusercontent.com/30889080/94439491-295d1900-01a9-11eb-95b4-8bf070f1b2fc.png)

After:
* `reference` field is optional and always pass validation
* Validation tip is never shown
![image](https://user-images.githubusercontent.com/30889080/94439659-5c071180-01a9-11eb-8b0f-a0aac22a1b48.png)
