### PR TITLE
Feat/38 create based on

### DIFF
--- a/src/components/table/EnhancedTable.tsx
+++ b/src/components/table/EnhancedTable.tsx
@@ -4,10 +4,11 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TablePagination from '@material-ui/core/TablePagination';
 import Paper from '@material-ui/core/Paper';
 import {Redirect} from 'react-router-dom';
-import {EnhancedTableToolbar} from "./EnhancedTableToolbar";
+import {EnhancedTableToolbar, ExtraToolbarButton} from "./EnhancedTableToolbar";
 import {EnhancedTableHead} from "./EnhancedTableHead";
 import {EnhancedTableBody} from "./EnhancedTableBody";
 import {Order, useTableStyles} from "./commons";
+import {SvgIconProps} from "@material-ui/core/SvgIcon/SvgIcon";
 
 
 export interface EnhancedReadonlyTableProps<T> {
@@ -20,6 +21,12 @@ export interface EnhancedReadonlyTableProps<T> {
     extractRow: (entity: T) => any[];
     extractRowValues: (entity: T) => any[];
     pageUrlPrefix: string;
+}
+
+interface SingleSelectedButton {
+    onClick: (id: string) => void;
+    text: string;
+    icon: (props: SvgIconProps) => JSX.Element;
 }
 
 export interface EnhancedTableProps<T> {
@@ -35,6 +42,7 @@ export interface EnhancedTableProps<T> {
     newUrlPrefix: string;
     pageUrlPrefix: string;
     cloneUrlPrefix?: string;
+    oneRowSelectedButtons?: SingleSelectedButton[];
 }
 
 export function EnhancedTable<T>(props: EnhancedTableProps<T> | EnhancedReadonlyTableProps<T>): React.ReactElement {
@@ -91,10 +99,24 @@ export function EnhancedTable<T>(props: EnhancedTableProps<T> | EnhancedReadonly
         return <Redirect push to={props.newUrlPrefix}/>
     }
 
-
-    // Redirect to the page where mew resource will be created
+    // Redirect to the page where new resource will be created
     if (!props.readonly && newCloneClicked) {
         return <Redirect push to={props.cloneUrlPrefix ? `${props.cloneUrlPrefix}/${selected[0]}` : ''}/>
+    }
+
+    // bind selected IDs to event handlers
+    let extraButtons: ExtraToolbarButton[] = [];
+    if (!props.readonly && selected.length === 1) {
+        const oneRowButtons: ExtraToolbarButton[] = (props.oneRowSelectedButtons ?? []).map(
+            v => {
+                return {
+                    ...v,
+                    onClick: () => {
+                        v.onClick(selected[0])
+                    }
+                }
+            })
+        extraButtons = extraButtons.concat(oneRowButtons)
     }
 
     return (
@@ -119,6 +141,7 @@ export function EnhancedTable<T>(props: EnhancedTableProps<T> | EnhancedReadonly
                                 props.onDeleteButtonClick(selected);
                                 setSelected([]);
                             }}
+                            extraButtons={extraButtons}
                         />
                     )
                 }

--- a/src/components/table/EnhancedTableToolbar.tsx
+++ b/src/components/table/EnhancedTableToolbar.tsx
@@ -7,6 +7,7 @@ import RefreshIcon from "@material-ui/icons/Refresh";
 import {Button, Divider} from "@material-ui/core";
 import React from "react";
 import FileCopyIcon from '@material-ui/icons/FileCopy';
+import {SvgIconProps} from "@material-ui/core/SvgIcon/SvgIcon";
 
 const useToolbarStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -28,14 +29,21 @@ const useToolbarStyles = makeStyles((theme: Theme) =>
     }),
 );
 
+export interface ExtraToolbarButton {
+    onClick: () => void;
+    text: string;
+    icon: (props: SvgIconProps) => JSX.Element;
+}
+
 interface SelectedTableToolbarProps {
     numSelected: number;
     onDeleteButtonClick: () => void;
     onNewCloneButtonClick: () => void;
+    extraButtons?: ExtraToolbarButton[];
 }
 
 const SelectedTableToolbar: React.FC<SelectedTableToolbarProps> = (
-    {numSelected, onDeleteButtonClick, onNewCloneButtonClick}
+    {numSelected, onDeleteButtonClick, onNewCloneButtonClick, extraButtons}
 ) => {
     const classes = useToolbarStyles();
 
@@ -59,6 +67,23 @@ const SelectedTableToolbar: React.FC<SelectedTableToolbarProps> = (
                     Clone
                 </Button>
             )}
+            {(extraButtons ?? [])
+                .map(v => {
+                    return <Button
+                        className={classes.button}
+                        variant="outlined"
+                        onClick={v.onClick}
+                        aria-label="new"
+                        key={v.text}
+                    >
+                        {React.createElement(
+                            v.icon,
+                            {className: classes.buttonIcon}
+                        )}
+                        {v.text}
+                    </Button>
+                })
+            }
             <Button
                 className={classes.button}
                 variant="outlined"

--- a/src/store/configuration/types.ts
+++ b/src/store/configuration/types.ts
@@ -18,3 +18,9 @@ export const defaultPackagingResourcesSelector = (state: ApplicationState) =>
 
 export const defaultPackagingOutputConnection = (state: ApplicationState) =>
     state.configuration.data.packaging?.outputConnectionID
+
+export const defaultDeploymentResourcesSelector = (state: ApplicationState) =>
+    state.configuration.data.deployment?.defaultResources
+
+export const defaultDeploymentImagePullConnSelector = (state: ApplicationState) =>
+    state.configuration.data.deployment?.defaultDockerPullConnName

--- a/src/store/configuration/types.ts
+++ b/src/store/configuration/types.ts
@@ -12,3 +12,9 @@ export const createKibanaEnabledSelector = () => (state: ApplicationState): bool
     state.configuration.data.common?.externalUrls
         ?.map((i) => i.name === 'Kibana')
         .indexOf(true) !== -1
+
+export const defaultPackagingResourcesSelector = (state: ApplicationState) =>
+    state.configuration.data.packaging?.defaultResources
+
+export const defaultPackagingOutputConnection = (state: ApplicationState) =>
+    state.configuration.data.packaging?.outputConnectionID

--- a/src/store/packagers/types.ts
+++ b/src/store/packagers/types.ts
@@ -1,4 +1,5 @@
 import {PackagingIntegration} from "../../models/odahuflow/PackagingIntegration";
+import {ApplicationState} from "../index";
 
 export interface PackagerState {
     readonly loading: boolean;
@@ -6,3 +7,7 @@ export interface PackagerState {
     readonly length: number;
     readonly error?: string;
 }
+
+
+export const packagerIDsSelector = (state: ApplicationState) =>
+    Object.values(state.packagers.data).map(packager => packager.id);

--- a/src/utils/basedCreating.test.ts
+++ b/src/utils/basedCreating.test.ts
@@ -73,5 +73,5 @@ test("If there is more than one docker-push target in packaging then we don't co
             ]
         }
     })
-    expect(deploymentSpec.imagePullConnID).toEqual("last-image")
+    expect(deploymentSpec.imagePullConnID).toEqual("")
 })

--- a/src/utils/basedCreating.test.ts
+++ b/src/utils/basedCreating.test.ts
@@ -1,4 +1,4 @@
-import {createPackagingSpecFromTraining} from "./basedCreating";
+import {createDeploymentSpecFromPackaging, createPackagingSpecFromTraining} from "./basedCreating";
 
 test("Output connection in Packaging must be the same as in Training", () => {
     const packagingSpec = createPackagingSpecFromTraining({
@@ -10,7 +10,7 @@ test("Output connection in Packaging must be the same as in Training", () => {
     expect(packagingSpec.outputConnection).toEqual("connection-123")
 })
 
-test("Artifact name must be as the last artifact in training", () => {
+test("Artifact name in Packaging must be equal to the last artifact in training", () => {
     const packagingSpec = createPackagingSpecFromTraining({
         id: "some-id",
         status: {
@@ -23,7 +23,7 @@ test("Artifact name must be as the last artifact in training", () => {
     expect(packagingSpec.artifactName).toEqual("last-run-artifact")
 })
 
-test("If no runs then artifact name in packaging should be empty", () => {
+test("If there are no training artifacts then artifact name in packaging should be empty", () => {
     const packagingSpec = createPackagingSpecFromTraining({
         id: "some-id",
         status: {
@@ -32,4 +32,46 @@ test("If no runs then artifact name in packaging should be empty", () => {
         }
     })
     expect(packagingSpec.artifactName).toEqual("")
+})
+
+test("Image in Deployment must be equal to last image in packaging", () => {
+    const deploymentSpec = createDeploymentSpecFromPackaging({
+        id: "some-id",
+        status: {
+            results: [
+                {name: "not-image", value: "some-value"},
+                {name: "image", value: "not-last-image"},
+                {name: "image", value: "last-image"},
+            ]
+        }
+    })
+    expect(deploymentSpec.image).toEqual("last-image")
+})
+
+test("If there is only one docker-push target in packaging then it must be copied to deployment", () => {
+    const deploymentSpec = createDeploymentSpecFromPackaging({
+        id: "some-id",
+        spec: {
+            targets: [
+                {name: "docker-pull", connectionName: "conn-1"},
+                {name: "docker-hack", connectionName: "conn-2"},
+                {name: "docker-push", connectionName: "conn-3"},
+            ]
+        }
+    })
+    expect(deploymentSpec.imagePullConnID).toEqual("conn-3")
+})
+
+test("If there is more than one docker-push target in packaging then we don't copy it to deployment", () => {
+    const deploymentSpec = createDeploymentSpecFromPackaging({
+        id: "some-id",
+        spec: {
+            targets: [
+                {name: "docker-pull", connectionName: "conn-1"},
+                {name: "docker-push", connectionName: "conn-2"},
+                {name: "docker-push", connectionName: "conn-3"},
+            ]
+        }
+    })
+    expect(deploymentSpec.imagePullConnID).toEqual("last-image")
 })

--- a/src/utils/basedCreating.test.ts
+++ b/src/utils/basedCreating.test.ts
@@ -1,0 +1,35 @@
+import {createPackagingSpecFromTraining} from "./basedCreating";
+
+test("Output connection in Packaging must be the same as in Training", () => {
+    const packagingSpec = createPackagingSpecFromTraining({
+        id: "some-id",
+        spec: {
+            outputConnection: "connection-123"
+        }
+    })
+    expect(packagingSpec.outputConnection).toEqual("connection-123")
+})
+
+test("Artifact name must be as the last artifact in training", () => {
+    const packagingSpec = createPackagingSpecFromTraining({
+        id: "some-id",
+        status: {
+            artifacts: [
+                {artifactName: "first-run-artifact"},
+                {artifactName: "last-run-artifact"},
+            ]
+        }
+    })
+    expect(packagingSpec.artifactName).toEqual("last-run-artifact")
+})
+
+test("If no runs then artifact name in packaging should be empty", () => {
+    const packagingSpec = createPackagingSpecFromTraining({
+        id: "some-id",
+        status: {
+            artifacts: [
+            ]
+        }
+    })
+    expect(packagingSpec.artifactName).toEqual("")
+})

--- a/src/utils/basedCreating.ts
+++ b/src/utils/basedCreating.ts
@@ -1,0 +1,28 @@
+/**
+ *
+ * This module contains different transformations
+ * ModelTraining -> ModelPackaging
+ * ModelPackaging -> ModelDeployment
+ * etc.
+ *
+ * The main idea is to speedup creating of next step in typical ML pipeline
+ *
+ * */
+import {ModelTraining} from "../models/odahuflow/ModelTraining";
+import {defaultPackagingSpec} from "./defaultEntities"
+import {ModelPackagingSpec} from "../models/odahuflow/ModelPackagingSpec";
+
+export const createPackagingSpecFromTraining = (mt: ModelTraining): ModelPackagingSpec => {
+
+    let artifactName = ""
+    const artifacts = mt.status?.artifacts ?? []
+    if (artifacts.length > 0) {
+        const lastArtifact = artifacts[artifacts.length - 1]
+        artifactName = lastArtifact.artifactName ?? ""
+    }
+
+    return defaultPackagingSpec({
+        outputConnection: mt.spec?.outputConnection,
+        artifactName: artifactName
+    })
+}

--- a/src/utils/basedCreating.ts
+++ b/src/utils/basedCreating.ts
@@ -9,8 +9,10 @@
  *
  * */
 import {ModelTraining} from "../models/odahuflow/ModelTraining";
-import {defaultPackagingSpec} from "./defaultEntities"
+import {defaultDeploymentSpec, defaultPackagingSpec} from "./defaultEntities"
 import {ModelPackagingSpec} from "../models/odahuflow/ModelPackagingSpec";
+import {ModelPackaging} from "../models/odahuflow/ModelPackaging";
+import {ModelDeploymentSpec} from "../models/odahuflow/ModelDeploymentSpec";
 
 export const createPackagingSpecFromTraining = (mt: ModelTraining): ModelPackagingSpec => {
 
@@ -24,5 +26,35 @@ export const createPackagingSpecFromTraining = (mt: ModelTraining): ModelPackagi
     return defaultPackagingSpec({
         outputConnection: mt.spec?.outputConnection,
         artifactName: artifactName
+    })
+}
+
+export const createDeploymentSpecFromPackaging = (mp: ModelPackaging): ModelDeploymentSpec => {
+
+    // there is not strict way
+    const imageKey = "image"
+    const dockerRepoKey = "docker-push"
+
+    let image = ""
+    const results = mp.status?.results ?? []
+    if (results.length > 0) {
+        const lastResult = results[results.length - 1]
+        if (lastResult.name === imageKey) {
+            image = lastResult.value ?? ""
+        }
+    }
+
+    let imagePullConnectionID = ""
+    const pushTargets = (mp.spec?.targets ?? [])
+        .filter(v => v.name === dockerRepoKey)
+        .map(v => v.connectionName ?? "")
+
+    if (pushTargets.length === 1) {
+        imagePullConnectionID = pushTargets[0]
+    }
+
+    return defaultDeploymentSpec({
+        image: image,
+        imagePullConnID: imagePullConnectionID
     })
 }

--- a/src/utils/defaultEntities.ts
+++ b/src/utils/defaultEntities.ts
@@ -1,0 +1,24 @@
+import {ModelPackagingSpec} from "../models/odahuflow/ModelPackagingSpec";
+import {merge} from "./enities";
+
+export function defaultPackagingSpec(mps?: ModelPackagingSpec): ModelPackagingSpec {
+    return merge({
+        artifactName: "",
+        integrationName: "",
+        outputConnection: "",
+        targets: [],
+        arguments: [],
+        resources: {
+            requests: {
+                cpu: '',
+                gpu: '',
+                memory: '',
+            },
+            limits: {
+                cpu: '',
+                gpu: '',
+                memory: '',
+            },
+        }
+    }, mps ?? {})
+}

--- a/src/utils/defaultEntities.ts
+++ b/src/utils/defaultEntities.ts
@@ -1,5 +1,6 @@
 import {ModelPackagingSpec} from "../models/odahuflow/ModelPackagingSpec";
 import {merge} from "./enities";
+import {ModelDeploymentSpec} from "../models/odahuflow/ModelDeploymentSpec";
 
 export function defaultPackagingSpec(mps?: ModelPackagingSpec): ModelPackagingSpec {
     return merge({
@@ -21,4 +22,25 @@ export function defaultPackagingSpec(mps?: ModelPackagingSpec): ModelPackagingSp
             },
         }
     }, mps ?? {})
+}
+
+export function defaultDeploymentSpec(mds?: ModelDeploymentSpec): ModelDeploymentSpec {
+    return merge({
+        livenessProbeInitialDelay: 10,
+        readinessProbeInitialDelay: 10,
+        minReplicas: 0,
+        maxReplicas: 1,
+        resources: {
+            requests: {
+                cpu: '',
+                gpu: '',
+                memory: '',
+            },
+            limits: {
+                cpu: '',
+                gpu: '',
+                memory: '',
+            },
+        }
+    }, mds ?? {})
 }

--- a/src/views/deployments/Deployment.tsx
+++ b/src/views/deployments/Deployment.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {Route, Switch} from "react-router-dom";
 import {DeploymentTable} from "./DeploymentTable";
-import {CloneDeploymentPage, NewDeploymentPage} from "./DeploymentPages";
+import {CloneDeploymentPage, NewDeploymentPage, CreateFromPackagingPage} from "./DeploymentPages";
 import {DeploymentViewPage} from "./DeploymentViewPage";
 import {DeploymentURLs} from "./urls";
 import {useFieldsStyles} from "../../components/fields";
@@ -22,6 +22,9 @@ export const Deployments: React.FC = () => {
                 </Route>
                 <Route path={join(DeploymentURLs.Clone, ':id')}>
                     <CloneDeploymentPage/>
+                </Route>
+                <Route path={join(DeploymentURLs.FromPackaging, ':id')}>
+                    <CreateFromPackagingPage/>
                 </Route>
             </Switch>
         </div>

--- a/src/views/deployments/DeploymentPages.tsx
+++ b/src/views/deployments/DeploymentPages.tsx
@@ -16,9 +16,17 @@ import {FetchingEntity} from "../../components/EntitiyFetching";
 import {addSuffixToID, merge} from "../../utils/enities";
 import {useSelector} from "react-redux";
 import {ApplicationState} from "../../store";
-import {ConfigurationState} from "../../store/configuration/types";
+import {
+    ConfigurationState,
+    defaultDeploymentImagePullConnSelector,
+    defaultDeploymentResourcesSelector
+} from "../../store/configuration/types";
 import { useHistory } from 'react-router-dom';
 import {DeploymentURLs} from "./urls";
+import {ModelPackaging} from "../../models/odahuflow/ModelPackaging";
+import {fetchPackagerRequest} from "../../store/packagers/actions";
+import {createDeploymentSpecFromPackaging} from "../../utils/basedCreating";
+import {fetchPackagingRequest} from "../../store/packaging/actions";
 
 const defaultFields = {
     schemas: {
@@ -80,7 +88,8 @@ export const EditableDeploymentPage: React.FC<EditableDeploymentPageProps> = ({d
 };
 
 export const NewDeploymentPage: React.FC = () => {
-    const config = useSelector<ApplicationState, ConfigurationState>(state => state.configuration);
+    const defaultResources = useSelector(defaultDeploymentResourcesSelector);
+    const defaultDockerPullConnName = useSelector(defaultDeploymentImagePullConnSelector);
 
     const history = useHistory()
     const btn = new SaveButtonClick<ModelDeployment>(
@@ -99,8 +108,8 @@ export const NewDeploymentPage: React.FC = () => {
             entity={{
                 id: '',
                 spec: defaultDeploymentSpec({
-                    resources: config.data.deployment?.defaultResources,
-                    imagePullConnID: config.data.deployment?.defaultDockerPullConnName,
+                    resources: defaultResources,
+                    imagePullConnID: defaultDockerPullConnName,
                 })
             }}
         />
@@ -134,6 +143,36 @@ export const CloneDeploymentPage: React.FC = () => {
                         }}
                     />
                 )
+            }
+        </FetchingEntity>
+    );
+};
+
+export const CreateFromPackagingPage: React.FC = () => {
+
+    const defaultResources = useSelector(defaultDeploymentResourcesSelector);
+    const defaultDockerPullConnName = useSelector(defaultDeploymentImagePullConnSelector);
+
+    return (
+        <FetchingEntity
+            fetchAction={fetchPackagingRequest}
+        >
+            {
+                (packaging: ModelPackaging) => {
+                    const deployment = createDeploymentSpecFromPackaging(packaging)
+                    return <EditablePage
+                        {...defaultFields}
+                        title="Create from Packaging"
+                        entity={{
+                            id: `${packaging.id}-deploy`,
+                            spec: {
+                                ...deployment,
+                                resources: defaultResources,
+                                imagePullConnID: deployment.imagePullConnID ?? defaultDockerPullConnName,
+                            }
+                        } as ModelDeployment}
+                    />
+                }
             }
         </FetchingEntity>
     );

--- a/src/views/deployments/DeploymentPages.tsx
+++ b/src/views/deployments/DeploymentPages.tsx
@@ -15,16 +15,13 @@ import {ModelDeploymentSpec} from "../../models/odahuflow/ModelDeploymentSpec";
 import {FetchingEntity} from "../../components/EntitiyFetching";
 import {addSuffixToID, merge} from "../../utils/enities";
 import {useSelector} from "react-redux";
-import {ApplicationState} from "../../store";
 import {
-    ConfigurationState,
     defaultDeploymentImagePullConnSelector,
     defaultDeploymentResourcesSelector
 } from "../../store/configuration/types";
 import { useHistory } from 'react-router-dom';
 import {DeploymentURLs} from "./urls";
 import {ModelPackaging} from "../../models/odahuflow/ModelPackaging";
-import {fetchPackagerRequest} from "../../store/packagers/actions";
 import {createDeploymentSpecFromPackaging} from "../../utils/basedCreating";
 import {fetchPackagingRequest} from "../../store/packaging/actions";
 

--- a/src/views/deployments/DeploymentPages.tsx
+++ b/src/views/deployments/DeploymentPages.tsx
@@ -153,6 +153,15 @@ export const CreateFromPackagingPage: React.FC = () => {
     const defaultResources = useSelector(defaultDeploymentResourcesSelector);
     const defaultDockerPullConnName = useSelector(defaultDeploymentImagePullConnSelector);
 
+    const history = useHistory()
+    const btn = new SaveButtonClick<ModelDeployment>(
+        createDeploymentRequest, fetchAllDeploymentRequest, "Model Deployment was created from packaging",
+        (entity) => {
+            const redirectTo = `${DeploymentURLs.Page}/${entity.id}`
+            history.push(redirectTo)
+        }
+    )
+
     return (
         <FetchingEntity
             fetchAction={fetchPackagingRequest}
@@ -162,6 +171,7 @@ export const CreateFromPackagingPage: React.FC = () => {
                     const deployment = createDeploymentSpecFromPackaging(packaging)
                     return <EditablePage
                         {...defaultFields}
+                        saveButtonClick={btn}
                         title="Create from Packaging"
                         entity={{
                             id: `${packaging.id}-deploy`,

--- a/src/views/deployments/urls.ts
+++ b/src/views/deployments/urls.ts
@@ -3,4 +3,5 @@ export enum DeploymentURLs {
     New = '/deployments/new',
     Page = '/deployments/item',
     Clone = '/deployments/clone',
+    FromPackaging = '/deployments/from-packaging',
 }

--- a/src/views/packagings/PackagingEditablePage.tsx
+++ b/src/views/packagings/PackagingEditablePage.tsx
@@ -133,7 +133,6 @@ export const NewPackagingPage: React.FC = () => {
     );
 };
 
-
 export const ClonePackagingPage: React.FC = () => {
 
     const history = useHistory()
@@ -173,6 +172,17 @@ export const CreateFromTrainingPage: React.FC = () => {
     const packagerIDs = useSelector(packagerIDsSelector);
     const defaultResources = useSelector(defaultPackagingResourcesSelector);
 
+    const history = useHistory()
+    const btn = new SaveButtonClick<ModelPackaging>(
+        createPackagingRequest,
+        fetchAllPackagingRequest,
+        "Packaging was created from training",
+        (entity) => {
+            const redirectTo = `${PackagingURLs.Page}/${entity.id}`
+            history.push(redirectTo)
+        }
+    )
+
     return (
         <FetchingEntity
             fetchAction={fetchTrainingRequest}
@@ -182,6 +192,7 @@ export const CreateFromTrainingPage: React.FC = () => {
                     return <EditablePage
                         {...defaultFields}
                         title="Create from Training"
+                        saveButtonClick={btn}
                         entity={{
                             id: `${training.id}-pack`,
                             spec: {

--- a/src/views/packagings/PackagingTable.tsx
+++ b/src/views/packagings/PackagingTable.tsx
@@ -61,7 +61,7 @@ export const PackagingTable: React.FC = () => {
     };
 
     if (redirectTo) {
-        return <Redirect push to={`${DeploymentURLs.Table}`}/>
+        return <Redirect push to={`${DeploymentURLs.FromPackaging}/${redirectTo}`}/>
     }
 
     return (

--- a/src/views/packagings/Packagings.tsx
+++ b/src/views/packagings/Packagings.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {Route, Switch} from "react-router-dom";
 import {PackagingTable} from "./PackagingTable";
-import {ClonePackagingPage, NewPackagingPage} from "./PackagingEditablePage";
+import {ClonePackagingPage, CreateFromTrainingPage, NewPackagingPage} from "./PackagingEditablePage";
 import {PackagingViewPage} from "./PackagingViewPage";
 import {PackagingURLs} from "./urls";
 import {join} from "path";
@@ -26,6 +26,9 @@ export const Packagings: React.FC = () => {
                 </Route>
                 <Route path={join(PackagingURLs.Clone, ':id')}>
                     <ClonePackagingPage/>
+                </Route>
+                <Route path={join(PackagingURLs.FromTraining, ':id')}>
+                    <CreateFromTrainingPage/>
                 </Route>
             </Switch>
         </div>

--- a/src/views/packagings/urls.tsx
+++ b/src/views/packagings/urls.tsx
@@ -2,5 +2,6 @@ export enum PackagingURLs {
     Table = '/packagings',
     New = '/packagings/new',
     Page = '/packagings/item',
-    Clone = '/packagings/clone'
+    Clone = '/packagings/clone',
+    FromTraining = '/packagings/from-training'
 }

--- a/src/views/trainings/TrainingTable.tsx
+++ b/src/views/trainings/TrainingTable.tsx
@@ -5,12 +5,14 @@ import {EnhancedTable, EnhancedTableProps} from "../../components/table/Enhanced
 import {ModelTraining} from "../../models/odahuflow/ModelTraining";
 import {ModelTrainingState} from "../../store/trainings/types";
 import {deleteTrainingRequest, fetchAllTrainingRequest} from "../../store/trainings/actions";
-import {Link as RouterLink} from "react-router-dom";
+import {Link as RouterLink, Redirect} from "react-router-dom";
 import {TrainingURLs} from "./urls";
 import {join} from "path";
 import {ConnectionURLs} from "../connections/urls";
 import {ToolchainURLs} from "../toolchains/urls";
 import {humanDate} from "../../utils/date";
+import {PackagingURLs} from "../packagings/urls";
+import SkipNextIcon from '@material-ui/icons/SkipNext';
 
 const TrainingEnhancedTable = (props: EnhancedTableProps<ModelTraining>) => <EnhancedTable {...props}/>;
 
@@ -44,6 +46,9 @@ const extractRowValues = (mt: ModelTraining) => [
 ];
 
 export const TrainingTable: React.FC = () => {
+
+    const [redirectTo, setRedirect] = React.useState<string>("")
+
     const trainingState = useSelector<ApplicationState, ModelTrainingState>(state => state.trainings);
     const dispatch = useDispatch();
 
@@ -59,6 +64,10 @@ export const TrainingTable: React.FC = () => {
         dispatch(fetchAllTrainingRequest());
     };
 
+    if (redirectTo) {
+        return <Redirect push to={`${PackagingURLs.FromTraining}/${redirectTo}`}/>
+    }
+
     return (
         <TrainingEnhancedTable
             readonly={false}
@@ -73,6 +82,13 @@ export const TrainingTable: React.FC = () => {
             newUrlPrefix={TrainingURLs.New}
             pageUrlPrefix={TrainingURLs.Page}
             cloneUrlPrefix={TrainingURLs.Clone}
+            oneRowSelectedButtons={[
+                {
+                    onClick: (id: string) => {setRedirect(id)},
+                    text: "Pack",
+                    icon: SkipNextIcon
+                }
+            ]}
         />
     );
 };

--- a/src/views/trainings/TrainingTable.tsx
+++ b/src/views/trainings/TrainingTable.tsx
@@ -12,7 +12,7 @@ import {ConnectionURLs} from "../connections/urls";
 import {ToolchainURLs} from "../toolchains/urls";
 import {humanDate} from "../../utils/date";
 import {PackagingURLs} from "../packagings/urls";
-import SkipNextIcon from '@material-ui/icons/SkipNext';
+import WorkIcon from '@material-ui/icons/Work';
 
 const TrainingEnhancedTable = (props: EnhancedTableProps<ModelTraining>) => <EnhancedTable {...props}/>;
 
@@ -86,7 +86,7 @@ export const TrainingTable: React.FC = () => {
                 {
                     onClick: (id: string) => {setRedirect(id)},
                     text: "Pack",
-                    icon: SkipNextIcon
+                    icon: WorkIcon
                 }
             ]}
         />


### PR DESCRIPTION
closes #38 

This PR simplifies creating packaging based on existing training and deployment based on packaging.
The app fills fields of an entity based on the original entity (e.g. takes the connection to artifact storage from training)

A new button "Pack" is added to the training table. This button is available if exactly one row is selected:
![image](https://user-images.githubusercontent.com/30889080/94937907-e10b6700-04d8-11eb-9caa-4efc0a8be2d6.png)

A new button "Pack" is added to the training table. This button is available if exactly one row is selected:
![image](https://user-images.githubusercontent.com/30889080/94938141-1d3ec780-04d9-11eb-90a7-944ab380a9fb.png)
