### PR TITLE
[#63] Fix routing in Toolchains and Packers sections

### DIFF
--- a/src/views/packagers/PackagerPage.tsx
+++ b/src/views/packagers/PackagerPage.tsx
@@ -5,18 +5,21 @@ import {PackagerView} from "./PackagerView";
 import {Editor} from "../../components/Editor";
 import {useFetchingEntity} from "../../components/EntitiyFetching";
 import {fetchPackagerRequest} from "../../store/packagers/actions";
+import {PackagerURLs} from "./urls";
 
 const tabHeaders = ["View", "YAML"];
 
 export const PackagerPage: React.FC = () => {
     const {id} = useParams();
     const {entity, loading, notFound} = useFetchingEntity(id as string, fetchPackagerRequest);
+    const baseUrl = `${PackagerURLs.Page}/${id}`
 
     return (
         <ViewPage
             loading={loading}
             notFound={notFound}
             tabHeaders={tabHeaders}
+            baseUrl={baseUrl}
             tabValues={[
                 <PackagerView
                     key="view"

--- a/src/views/toolchains/ToolchainPage.tsx
+++ b/src/views/toolchains/ToolchainPage.tsx
@@ -5,18 +5,21 @@ import {ToolchainView} from "./ToolchainView";
 import {Editor} from "../../components/Editor";
 import {useFetchingEntity} from "../../components/EntitiyFetching";
 import {fetchToolchainRequest} from "../../store/toolchains/actions";
+import {ToolchainURLs} from "./urls";
 
 const tabHeaders = ["View", "YAML"];
 
 export const ToolchainPage: React.FC = () => {
     const {id} = useParams();
     const {entity, loading, notFound} = useFetchingEntity(id as string, fetchToolchainRequest);
+    const baseUrl = `${ToolchainURLs.Page}/${id}`
 
     return (
         <ViewPage
             loading={loading}
             notFound={notFound}
             tabHeaders={tabHeaders}
+            baseUrl={baseUrl}
             tabValues={[
                 <ToolchainView
                     key="view"


### PR DESCRIPTION
Fixes #63 

The cause of the bug was a missing parameter `baseUrl`, that is used for building links for tab buttons like View/YAML/...
Here's an example of usage of `baseUrl` on Training page: https://github.com/odahu/odahu-ui/blob/fix/63-routing-ti-pi/src/views/trainings/TrainingPage.tsx#L63