### PR TITLE
[#80] Properly validate default Predictor

### DIFF
--- a/src/components/OdahuSelect.tsx
+++ b/src/components/OdahuSelect.tsx
@@ -16,7 +16,6 @@ export const FormikOdahuSelect: React.FC<FormikOdahuSelectProps> = (
     }
 ) => {
     const formik = useFormikContext();
-    console.log(formik)
     const fieldsOptions = useContext<FieldsOptions>(FieldsOptionsContext);
 
     return (

--- a/src/components/OdahuSelect.tsx
+++ b/src/components/OdahuSelect.tsx
@@ -16,6 +16,7 @@ export const FormikOdahuSelect: React.FC<FormikOdahuSelectProps> = (
     }
 ) => {
     const formik = useFormikContext();
+    console.log(formik)
     const fieldsOptions = useContext<FieldsOptions>(FieldsOptionsContext);
 
     return (

--- a/src/views/connections/ConnectionEditablePage.tsx
+++ b/src/views/connections/ConnectionEditablePage.tsx
@@ -86,7 +86,6 @@ const MetadataElements: React.FC<MetadataElementsPros> = ({readonlyID}) => {
                 className={classes.editorField}
                 name='spec.type'
                 label="Type"
-                defaultValue={ConnectionTypes.AZUREBLOB}
                 options={allConnectionTypes}
             />
             <OdahuTextField

--- a/src/views/deployments/DeploymentPages.tsx
+++ b/src/views/deployments/DeploymentPages.tsx
@@ -24,6 +24,7 @@ import {DeploymentURLs} from "./urls";
 import {ModelPackaging} from "../../models/odahuflow/ModelPackaging";
 import {createDeploymentSpecFromPackaging} from "../../utils/basedCreating";
 import {fetchPackagingRequest} from "../../store/packaging/actions";
+import {predictorOdahu} from "../../utils/enums";
 
 const defaultFields = {
     schemas: {
@@ -107,6 +108,7 @@ export const NewDeploymentPage: React.FC = () => {
                 spec: defaultDeploymentSpec({
                     resources: defaultResources,
                     imagePullConnID: defaultDockerPullConnName,
+                    predictor: predictorOdahu,
                 })
             }}
         />

--- a/src/views/deployments/editable/SpecElements.tsx
+++ b/src/views/deployments/editable/SpecElements.tsx
@@ -29,7 +29,6 @@ export const SpecElements: React.FC = () => {
                 label="Predictor"
                 name="spec.predictor"
                 options={predictors}
-                defaultValue={predictorOdahu}
                 description="Predictor set ML Server that will serve model as a web service"
             />
             <FormikOdahuAutocomplete

--- a/src/views/packagings/editable/MetadataElements.tsx
+++ b/src/views/packagings/editable/MetadataElements.tsx
@@ -46,7 +46,6 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
                 name="spec.integrationName"
                 label="Integration"
                 options={packagerIDs}
-                defaultValue={packagerIDs[0]}
                 description='Type of a packager'
             />
         </>

--- a/src/views/packagings/editable/SpecElements.tsx
+++ b/src/views/packagings/editable/SpecElements.tsx
@@ -48,13 +48,11 @@ const Targets: React.FC = () => {
                                 <FormikOdahuSelect
                                     name={`spec.targets[${index}].name`}
                                     label="Name"
-                                    defaultValue={targetNames[0]}
                                     options={targetNames}
                                 />
                                 <FormikOdahuSelect
                                     name={`spec.targets[${index}].connectionName`}
                                     label="Connection ID"
-                                    defaultValue={connectionIDs[0]}
                                     options={connectionIDs}
                                 />
                             </ItemInputParametersView>

--- a/src/views/trainings/editable/MetadataElements.tsx
+++ b/src/views/trainings/editable/MetadataElements.tsx
@@ -50,7 +50,6 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
                 className={classes.editorField}
                 name="spec.toolchain"
                 label="Toolchain"
-                defaultValue={toolchainIDs[0]}
                 options={toolchainIDs}
             />
             <FormikOdahuSelect

--- a/src/views/trainings/editable/SpecElements.tsx
+++ b/src/views/trainings/editable/SpecElements.tsx
@@ -124,7 +124,6 @@ const DataSection: React.FC = () => {
                                 <FormikOdahuSelect
                                     name={`spec.data.${index}.connName`}
                                     label="Connection ID"
-                                    defaultValue={connectionIDs[0]}
                                     options={connectionIDs}
                                 />
                             </ItemInputParametersView>


### PR DESCRIPTION
Fixes #80.
The way we use `defaultValue` is wrong, as far as I can see. It doesn't affect the form behavior or affects in some undesired way. Initial (default) values for form are taken from formik context, so this is where they should be configured. Also I tried to remove `defaultValue` from everywhere and seems like it changed nothing...

![predictors_default_validation](https://user-images.githubusercontent.com/25623173/107525517-f8b1d500-6bc7-11eb-8019-7067ec3279ce.gif)
