### PR TITLE
[#81] Suggest Triton images in deployment image field

### DIFF
--- a/src/views/deployments/editable/SpecElements.tsx
+++ b/src/views/deployments/editable/SpecElements.tsx
@@ -7,7 +7,7 @@ import {OdahuTextField} from "../../../components/OdahuTextField";
 import {ResourcesSpecElements} from "../../../components/ResourceSpecElements";
 import {useFieldsStyles} from "../../../components/fields";
 import {FormikOdahuSelect} from "../../../components/OdahuSelect";
-import {predictors, predictorOdahu} from "../../../utils/enums"
+import {predictors, predictorOdahu, deployableIntegrations} from "../../../utils/enums"
 
 
 export const SpecElements: React.FC = () => {
@@ -16,7 +16,7 @@ export const SpecElements: React.FC = () => {
     const packagerState = useSelector<ApplicationState, ModelPackagingState>(state => state.packagings);
     const packagingImages = Object.values(packagerState.data)
         // TODO: fix the hardcoded intergration name
-        .filter(mp => mp.spec?.integrationName === "docker-rest")
+        .filter(mp => mp.spec?.integrationName && deployableIntegrations.includes(mp.spec.integrationName))
         .filter(mp => mp.status?.state === "succeeded")
         .filter(mp => mp.status?.results)
         .flatMap(mp => mp.status?.results)


### PR DESCRIPTION
Added Triton images to complete-suggestions in `Image` field of new `Deployment`.
Fixes #81.

Demo: 
1. Check that there is a successful Triton packaging; resulted in a docker image
2. Show that the image is suggested in `Image` dropdown in new Deployment form
![triton_images_competions](https://user-images.githubusercontent.com/25623173/107538485-16d20200-6bd5-11eb-95aa-f0a00cba21a3.gif)
