### PR TITLE
[#84] Hide Git Secret Key in edit form

### DIFF
--- a/src/views/connections/types/git.tsx
+++ b/src/views/connections/types/git.tsx
@@ -47,7 +47,6 @@ export const EditableFields: React.FC = () => {
                 name="spec.keySecret"
                 label="SSH private key"
                 description='base64 encoded SSH private key'
-                multiline={true}
             />
         </>
     )


### PR DESCRIPTION
Fixed by removing multiline option of text field. Since Key Secret is base64 encoded it doesn't need multiline input anymore.

![git-hide-secret](https://user-images.githubusercontent.com/25623173/114382001-7f693b00-9b94-11eb-81fa-23327d7c72f4.gif)

Fixes #84 