### PR TITLE
[#17] Red asterisks for required fields

### DIFF
--- a/src/components/EditablePage.tsx
+++ b/src/components/EditablePage.tsx
@@ -11,7 +11,6 @@ import {Formik, useFormikContext} from "formik";
 import {ObjectSchema} from "yup";
 import {useDispatch} from "react-redux";
 import {SaveButtonClick} from "./actions";
-import {formLabelsTheme} from "./fields";
 
 const specificationTitle = 'Specification';
 const metadataTitle = 'Metadata';

--- a/src/components/EditablePage.tsx
+++ b/src/components/EditablePage.tsx
@@ -259,59 +259,57 @@ export function EditablePage<T extends { id?: string }>(props: EditPageProps<T>)
                 >
                     {
                         (formik) => (
-                            <MuiThemeProvider theme={formLabelsTheme}>
-                                <form onSubmit={formik.handleSubmit}>
-                                    <Typography
-                                        style={{padding: "15px"}}
-                                        variant="h6"
-                                    >
-                                        {title}
-                                    </Typography>
-                                    <Stepper
-                                        activeStep={activeStep}
-                                        orientation="vertical"
-                                    >
-                                        <Step key={metadataTitle}>
-                                            <StepLabel>{metadataTitle}</StepLabel>
-                                            <StepContent>
-                                                <FieldsOptionsContext.Provider value={metadataFieldOptions}>
-                                                    <MetadataStep
-                                                        handleNext={handleNext}
-                                                        fields={fields.metadata()}
-                                                        schema={schemas.metadata}
-                                                        setFieldOptions={setMetadataFieldOptions}
-                                                    />
-                                                </FieldsOptionsContext.Provider>
-                                            </StepContent>
-                                        </Step>
-                                        <Step key={specificationTitle}>
-                                            <StepLabel>{specificationTitle}</StepLabel>
-                                            <StepContent>
-                                                <FieldsOptionsContext.Provider value={specFieldOptions}>
-                                                    <SpecStep
-                                                        schema={props.schemas.spec}
-                                                        handleBack={handleBack}
-                                                        handleNext={handleNext}
-                                                        fields={fields.spec()}
-                                                        setFieldOptions={setSpecFieldOptions}
-                                                    />
-                                                </FieldsOptionsContext.Provider>
-                                            </StepContent>
-                                        </Step>
-                                        <Step key={reviewTitle}>
-                                            <StepLabel>{reviewTitle}</StepLabel>
-                                            <StepContent>
-                                                <ReviewStep
-                                                    values={formik.values}
-                                                    handleBack={handleBack}
-                                                    fields={fields.review(formik.values)}
+                            <form onSubmit={formik.handleSubmit}>
+                                <Typography
+                                    style={{padding: "15px"}}
+                                    variant="h6"
+                                >
+                                    {title}
+                                </Typography>
+                                <Stepper
+                                    activeStep={activeStep}
+                                    orientation="vertical"
+                                >
+                                    <Step key={metadataTitle}>
+                                        <StepLabel>{metadataTitle}</StepLabel>
+                                        <StepContent>
+                                            <FieldsOptionsContext.Provider value={metadataFieldOptions}>
+                                                <MetadataStep
+                                                    handleNext={handleNext}
+                                                    fields={fields.metadata()}
+                                                    schema={schemas.metadata}
+                                                    setFieldOptions={setMetadataFieldOptions}
                                                 />
-                                            </StepContent>
-                                        </Step>
-                                        <ValidateForm/>
-                                    </Stepper>
-                                </form>
-                            </MuiThemeProvider>
+                                            </FieldsOptionsContext.Provider>
+                                        </StepContent>
+                                    </Step>
+                                    <Step key={specificationTitle}>
+                                        <StepLabel>{specificationTitle}</StepLabel>
+                                        <StepContent>
+                                            <FieldsOptionsContext.Provider value={specFieldOptions}>
+                                                <SpecStep
+                                                    schema={props.schemas.spec}
+                                                    handleBack={handleBack}
+                                                    handleNext={handleNext}
+                                                    fields={fields.spec()}
+                                                    setFieldOptions={setSpecFieldOptions}
+                                                />
+                                            </FieldsOptionsContext.Provider>
+                                        </StepContent>
+                                    </Step>
+                                    <Step key={reviewTitle}>
+                                        <StepLabel>{reviewTitle}</StepLabel>
+                                        <StepContent>
+                                            <ReviewStep
+                                                values={formik.values}
+                                                handleBack={handleBack}
+                                                fields={fields.review(formik.values)}
+                                            />
+                                        </StepContent>
+                                    </Step>
+                                    <ValidateForm/>
+                                </Stepper>
+                            </form>
                         )
                     }
                 </Formik>

--- a/src/components/EditablePage.tsx
+++ b/src/components/EditablePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createStyles, makeStyles, Theme} from '@material-ui/core/styles';
+import {createStyles, makeStyles, MuiThemeProvider, Theme} from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
@@ -11,6 +11,7 @@ import {Formik, useFormikContext} from "formik";
 import {ObjectSchema} from "yup";
 import {useDispatch} from "react-redux";
 import {SaveButtonClick} from "./actions";
+import {formLabelsTheme} from "./fields";
 
 const specificationTitle = 'Specification';
 const metadataTitle = 'Metadata';
@@ -258,57 +259,59 @@ export function EditablePage<T extends { id?: string }>(props: EditPageProps<T>)
                 >
                     {
                         (formik) => (
-                            <form onSubmit={formik.handleSubmit}>
-                                <Typography
-                                    style={{padding: "15px"}}
-                                    variant="h6"
-                                >
-                                    {title}
-                                </Typography>
-                                <Stepper
-                                    activeStep={activeStep}
-                                    orientation="vertical"
-                                >
-                                    <Step key={metadataTitle}>
-                                        <StepLabel>{metadataTitle}</StepLabel>
-                                        <StepContent>
-                                            <FieldsOptionsContext.Provider value={metadataFieldOptions}>
-                                                <MetadataStep
-                                                    handleNext={handleNext}
-                                                    fields={fields.metadata()}
-                                                    schema={schemas.metadata}
-                                                    setFieldOptions={setMetadataFieldOptions}
-                                                />
-                                            </FieldsOptionsContext.Provider>
-                                        </StepContent>
-                                    </Step>
-                                    <Step key={specificationTitle}>
-                                        <StepLabel>{specificationTitle}</StepLabel>
-                                        <StepContent>
-                                            <FieldsOptionsContext.Provider value={specFieldOptions}>
-                                                <SpecStep
-                                                    schema={props.schemas.spec}
+                            <MuiThemeProvider theme={formLabelsTheme}>
+                                <form onSubmit={formik.handleSubmit}>
+                                    <Typography
+                                        style={{padding: "15px"}}
+                                        variant="h6"
+                                    >
+                                        {title}
+                                    </Typography>
+                                    <Stepper
+                                        activeStep={activeStep}
+                                        orientation="vertical"
+                                    >
+                                        <Step key={metadataTitle}>
+                                            <StepLabel>{metadataTitle}</StepLabel>
+                                            <StepContent>
+                                                <FieldsOptionsContext.Provider value={metadataFieldOptions}>
+                                                    <MetadataStep
+                                                        handleNext={handleNext}
+                                                        fields={fields.metadata()}
+                                                        schema={schemas.metadata}
+                                                        setFieldOptions={setMetadataFieldOptions}
+                                                    />
+                                                </FieldsOptionsContext.Provider>
+                                            </StepContent>
+                                        </Step>
+                                        <Step key={specificationTitle}>
+                                            <StepLabel>{specificationTitle}</StepLabel>
+                                            <StepContent>
+                                                <FieldsOptionsContext.Provider value={specFieldOptions}>
+                                                    <SpecStep
+                                                        schema={props.schemas.spec}
+                                                        handleBack={handleBack}
+                                                        handleNext={handleNext}
+                                                        fields={fields.spec()}
+                                                        setFieldOptions={setSpecFieldOptions}
+                                                    />
+                                                </FieldsOptionsContext.Provider>
+                                            </StepContent>
+                                        </Step>
+                                        <Step key={reviewTitle}>
+                                            <StepLabel>{reviewTitle}</StepLabel>
+                                            <StepContent>
+                                                <ReviewStep
+                                                    values={formik.values}
                                                     handleBack={handleBack}
-                                                    handleNext={handleNext}
-                                                    fields={fields.spec()}
-                                                    setFieldOptions={setSpecFieldOptions}
+                                                    fields={fields.review(formik.values)}
                                                 />
-                                            </FieldsOptionsContext.Provider>
-                                        </StepContent>
-                                    </Step>
-                                    <Step key={reviewTitle}>
-                                        <StepLabel>{reviewTitle}</StepLabel>
-                                        <StepContent>
-                                            <ReviewStep
-                                                values={formik.values}
-                                                handleBack={handleBack}
-                                                fields={fields.review(formik.values)}
-                                            />
-                                        </StepContent>
-                                    </Step>
-                                    <ValidateForm/>
-                                </Stepper>
-                            </form>
+                                            </StepContent>
+                                        </Step>
+                                        <ValidateForm/>
+                                    </Stepper>
+                                </form>
+                            </MuiThemeProvider>
                         )
                     }
                 </Formik>

--- a/src/components/OdahuAutocomplete.tsx
+++ b/src/components/OdahuAutocomplete.tsx
@@ -43,13 +43,14 @@ export interface OdahuAutocompleteProps {
     // Error or description text
     helperText?: string;
     className?: string;
+    required?: boolean
 }
 
 /**
  * The proxy component for material UI Autocomplete
  */
 export const OdahuAutocomplete: React.FC<OdahuAutocompleteProps> = (
-    {className, options, name, value, label,error, helperText}
+    {required, className, options, name, value, label,error, helperText}
 ) => {
     const classes = editPageStyles();
     const formik = useFormikContext();
@@ -66,6 +67,7 @@ export const OdahuAutocomplete: React.FC<OdahuAutocompleteProps> = (
             renderInput={params => (
                 <TextField {...params}
                            name={name}
+                           required={required}
                            onChange={formik.handleChange}
                            error={error}
                            helperText={helperText}

--- a/src/components/OdahuSelect.tsx
+++ b/src/components/OdahuSelect.tsx
@@ -41,6 +41,7 @@ export const OdahuSelect: React.FC<OdahuSelectProps> = (
     {
         label,
         name,
+        required,
         onChange,
         value,
         defaultValue,
@@ -54,6 +55,7 @@ export const OdahuSelect: React.FC<OdahuSelectProps> = (
 
     return (
         <FormControl
+            required={required}
             className={className ?? classes.fields}
             error={error}
         >

--- a/src/components/SecretTextField.tsx
+++ b/src/components/SecretTextField.tsx
@@ -36,7 +36,10 @@ export type SecretTextFieldProps = {
     helperText?: string;
 } & InputProps;
 
-export const SecretTextField: React.FC<SecretTextFieldProps> = ({className, error, helperText, label, ...otherProps}) => {
+export const SecretTextField: React.FC<SecretTextFieldProps> = ({
+    required, className, error,
+    helperText, label, ...otherProps
+}) => {
     const classes = useFieldsStyles();
 
     const [showPassword, setShowPassword] = React.useState(false);
@@ -46,7 +49,7 @@ export const SecretTextField: React.FC<SecretTextFieldProps> = ({className, erro
     };
 
     return (
-        <FormControl className={className ?? classes.fields} error={error}>
+        <FormControl required={required} className={className ?? classes.fields} error={error}>
             <InputLabel>{label}</InputLabel>
             <Input
                 type={showPassword ? 'text' : 'password'}

--- a/src/components/fields.tsx
+++ b/src/components/fields.tsx
@@ -1,7 +1,6 @@
 import {createStyles, makeStyles, Theme} from "@material-ui/core/styles";
 import * as Yup from "yup";
 import {isValidID} from "../utils/enities";
-import {createMuiTheme} from "@material-ui/core";
 
 export const maxFieldWidth = '500px';
 export const fieldMargin = '20px';
@@ -45,19 +44,6 @@ export const useFieldsStyles = makeStyles((theme: Theme) =>
         }
     }),
 );
-
-export const formLabelsTheme = createMuiTheme({
-    overrides: {
-        MuiFormLabel: {
-            asterisk: {
-                color: '#db3131',
-                '&$error': {
-                    color: '#db3131'
-                },
-            }
-        }
-    }
-})
 
 export const IDSchema = Yup.string().required('ID is a required value')
     .test("id", "ID is not valid", isValidID);

--- a/src/components/fields.tsx
+++ b/src/components/fields.tsx
@@ -1,6 +1,7 @@
 import {createStyles, makeStyles, Theme} from "@material-ui/core/styles";
 import * as Yup from "yup";
 import {isValidID} from "../utils/enities";
+import {createMuiTheme} from "@material-ui/core";
 
 export const maxFieldWidth = '500px';
 export const fieldMargin = '20px';
@@ -38,9 +39,25 @@ export const useFieldsStyles = makeStyles((theme: Theme) =>
             textAlign: 'left',
             lineHeight: '1em',
             letterSpacing: '0.03333em',
+        },
+        "MuiFormLabel-asterisk": {
+            color: 'red',
         }
     }),
 );
+
+export const formLabelsTheme = createMuiTheme({
+    overrides: {
+        MuiFormLabel: {
+            asterisk: {
+                color: '#db3131',
+                '&$error': {
+                    color: '#db3131'
+                },
+            }
+        }
+    }
+})
 
 export const IDSchema = Yup.string().required('ID is a required value')
     .test("id", "ID is not valid", isValidID);

--- a/src/configureTheme.ts
+++ b/src/configureTheme.ts
@@ -12,5 +12,15 @@ export function configureTheme() {
                 light: 'rgb(87, 114, 137)'
             },
         },
+        overrides: {
+            MuiFormLabel: {
+                asterisk: {
+                    color: '#db3131',
+                    '&$error': {
+                        color: '#db3131'
+                    },
+                }
+            }
+        }
     });
 }

--- a/src/views/connections/ConnectionEditablePage.tsx
+++ b/src/views/connections/ConnectionEditablePage.tsx
@@ -76,6 +76,7 @@ const MetadataElements: React.FC<MetadataElementsPros> = ({readonlyID}) => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 disabled={readonlyID}
                 name="id"
@@ -83,6 +84,7 @@ const MetadataElements: React.FC<MetadataElementsPros> = ({readonlyID}) => {
                 description="Unique value among all connections"
             />
             <FormikOdahuSelect
+                required
                 className={classes.editorField}
                 name='spec.type'
                 label="Type"

--- a/src/views/connections/types/azureblob.tsx
+++ b/src/views/connections/types/azureblob.tsx
@@ -25,12 +25,14 @@ const EditableFields: React.FC = () => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.uri"
                 label="URI"
                 description="Azure storage compatible URI, for example <bucket-name>/dir1/dir2/"
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name='spec.keySecret'
                 label="SAS Token"

--- a/src/views/connections/types/docker.tsx
+++ b/src/views/connections/types/docker.tsx
@@ -28,18 +28,21 @@ export const EditableFields: React.FC = () => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.uri"
                 label="URI"
                 description="Docker registry host, for example: gcr.io/project/odahuflow"
             />
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.username"
                 label="Username"
                 description='Docker registry username'
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name="spec.password"
                 label="Password"

--- a/src/views/connections/types/ecr.tsx
+++ b/src/views/connections/types/ecr.tsx
@@ -30,6 +30,7 @@ export const EditableFields: React.FC = () => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.uri"
                 label="URI"
@@ -41,12 +42,14 @@ export const EditableFields: React.FC = () => {
                 label="Region"
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name="spec.keyID"
                 label="Access Key ID"
                 description='Base64-encoded access key ID (for example, "QUtJQUlPU0ZPRE5ON0VYQU1QTEU=").'
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name="spec.keySecret"
                 label="Access Key Secret"

--- a/src/views/connections/types/gcs.tsx
+++ b/src/views/connections/types/gcs.tsx
@@ -28,18 +28,21 @@ export const EditableFields: React.FC = () => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.region"
                 label="Project"
                 description='GCP Project, where a bucket was created'
             />
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.uri"
                 label="URI"
                 description='GCS compatible URI, for example gcs://<bucket-name>/dir1/dir2/'
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name="spec.keySecret"
                 label="Service account secret"

--- a/src/views/connections/types/git.tsx
+++ b/src/views/connections/types/git.tsx
@@ -30,6 +30,7 @@ export const EditableFields: React.FC = () => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.uri"
                 label="Git SSH URL"
@@ -43,6 +44,7 @@ export const EditableFields: React.FC = () => {
                 description='a branch, tag, or commit'
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name="spec.keySecret"
                 label="SSH private key"

--- a/src/views/connections/types/s3.tsx
+++ b/src/views/connections/types/s3.tsx
@@ -53,24 +53,28 @@ export const EditableFields: React.FC = () => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.uri"
                 label="URI"
                 description='S3 compatible URI, for example s3://<bucket-name>/dir1/dir2/'
             />
             <FormikOdahuAutocomplete
+                required
                 className={classes.editorField}
                 name="spec.region"
                 label="Region"
                 options={ALL_AWS_REGIONS}
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name="spec.keyID"
                 label="Access Key ID"
                 description='Base64-encoded access key ID (for example, "QUtJQUlPU0ZPRE5ON0VYQU1QTEU=").'
             />
             <FormikSecretTextField
+                required
                 className={classes.editorField}
                 name="spec.keySecret"
                 label="Access Key Secret"

--- a/src/views/deployments/editable/MetadataElements.tsx
+++ b/src/views/deployments/editable/MetadataElements.tsx
@@ -22,6 +22,7 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 disabled={readonlyID}
                 name="id"
@@ -29,6 +30,7 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
                 description="Unique value among all deployments"
             />
             <FormikOdahuSelect
+                required
                 className={classes.editorField}
                 label="Image pull connection ID"
                 name="spec.imagePullConnID"

--- a/src/views/deployments/editable/SpecElements.tsx
+++ b/src/views/deployments/editable/SpecElements.tsx
@@ -24,6 +24,7 @@ export const SpecElements: React.FC = () => {
     return (
         <>
             <FormikOdahuSelect
+                required
                 className={classes.editorField}
                 label="Predictor"
                 name="spec.predictor"
@@ -31,6 +32,7 @@ export const SpecElements: React.FC = () => {
                 description="Predictor set ML Server that will serve model as a web service"
             />
             <FormikOdahuAutocomplete
+                required
                 className={classes.editorField}
                 name="spec.image"
                 label="Docker image"

--- a/src/views/packagings/editable/MetadataElements.tsx
+++ b/src/views/packagings/editable/MetadataElements.tsx
@@ -28,6 +28,7 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 disabled={readonlyID}
                 name="id"
@@ -35,6 +36,7 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
                 description='Unique value among all packagings'
             />
             <FormikOdahuSelect
+                required
                 className={classes.editorField}
                 name="spec.outputConnection"
                 label="Output Connection ID"
@@ -42,6 +44,7 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
                 description='Bucket where the Trained Model Binary is stored'
             />
             <FormikOdahuSelect
+                required
                 className={classes.editorField}
                 name="spec.integrationName"
                 label="Integration"

--- a/src/views/packagings/editable/SpecElements.tsx
+++ b/src/views/packagings/editable/SpecElements.tsx
@@ -127,6 +127,7 @@ export const SpecElements: React.FC = () => {
     return (
         <>
             <FormikOdahuAutocomplete
+                required
                 className={classes.editorField}
                 name="spec.artifactName"
                 label='Artifact'

--- a/src/views/packagings/editable/schemas.ts
+++ b/src/views/packagings/editable/schemas.ts
@@ -14,7 +14,7 @@ export const PackagingSchema = Yup.object().shape({
     id: IDSchema,
     spec: Yup.object().shape({
         integrationName: Yup.string().trim().required('Integration name is a required field'),
-        outputConnection: Yup.string().trim(),
+        outputConnection: Yup.string().trim().required('Output Connection is a required field'),
         artifactName: Yup.string().trim().required('Artifact name is a required field'),
         targets: Yup.array().of(
             Yup.object().shape({

--- a/src/views/trainings/editable/MetadataElements.tsx
+++ b/src/views/trainings/editable/MetadataElements.tsx
@@ -28,6 +28,7 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 disabled={readonlyID}
                 name="id"
@@ -35,24 +36,28 @@ export const MetadataElements: React.FC<MetadataElementsProps> = ({readonlyID = 
                 description="Unique value among all trainings"
             />
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.model.name"
                 label='Model name'
                 description='Human-readable model name'
             />
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.model.version"
                 label='Model version'
                 description='Human-readable model value'
             />
             <FormikOdahuSelect
+                required
                 className={classes.editorField}
                 name="spec.toolchain"
                 label="Toolchain"
                 options={toolchainIDs}
             />
             <FormikOdahuSelect
+                required
                 className={classes.editorField}
                 name="spec.outputConnection"
                 label="Output connection"

--- a/src/views/trainings/editable/SpecElements.tsx
+++ b/src/views/trainings/editable/SpecElements.tsx
@@ -56,6 +56,7 @@ const GitSpecElements: React.FC = () => {
             <Divider/>
             <div className={trainClasses.gitContent}>
                 <FormikOdahuSelect
+                    required
                     name="spec.vcsName"
                     label="VCS ID"
                     options={vcsConnectionIDs}
@@ -129,6 +130,7 @@ const DataSection: React.FC = () => {
                             </ItemInputParametersView>
                         )
                     )}
+                    <div>{formik.errors.spec?["data"]:1}</div>
                 </InputParametersView>
             )}
         />
@@ -217,6 +219,7 @@ export const SpecElements: React.FC = () => {
     return (
         <>
             <OdahuTextField
+                required
                 className={classes.editorField}
                 name="spec.entrypoint"
                 label='Entrypoint'

--- a/src/views/trainings/editable/SpecElements.tsx
+++ b/src/views/trainings/editable/SpecElements.tsx
@@ -130,7 +130,6 @@ const DataSection: React.FC = () => {
                             </ItemInputParametersView>
                         )
                     )}
-                    <div>{formik.errors.spec?["data"]:1}</div>
                 </InputParametersView>
             )}
         />

--- a/src/views/trainings/editable/schemas.ts
+++ b/src/views/trainings/editable/schemas.ts
@@ -35,7 +35,7 @@ export const TrainingSchema = Yup.object().shape({
                 value: Yup.string().trim().required('Value is a required field'),
             })
         ),
-        data: Yup.array().of(
+        data: Yup.array().min(1, 'Add at least 1 data source').of(
             Yup.object().shape({
                 connName: Yup.string().trim().required('Connection ID is a required field'),
                 localPath: Yup.string().trim().required('Target path is a required field'),


### PR DESCRIPTION
Unfortunately, Yum library doesn't allow inspecting a built spec object to determine if the field marked required or not. So adding the asterisk to a field is manual and actually duplicates the definition of required fields from spec.

![image](https://user-images.githubusercontent.com/25623173/115387913-f1203500-a1e3-11eb-91df-4f399467955f.png)
